### PR TITLE
has_spree_role? needs to be redefineed

### DIFF
--- a/config/initializers/user_class_extensions.rb
+++ b/config/initializers/user_class_extensions.rb
@@ -1,0 +1,10 @@
+Spree::Core::Engine.config.to_prepare do
+  if Spree.user_class
+    Spree.user_class.class_eval do
+      def has_spree_role?(role_in_question)
+        spree_roles.any?{ |r| r.name == role_in_question.to_s.camelize || r.name == role_in_question.to_s }
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
`has_spree_role?` fails since the redefined `spree_roles` (in alchemy_spree -> user_decorator.rb) isn't an activerecord object.

Reference http://git.io/wUwXCA
