### PR TITLE
Removing 'readonly' key

### DIFF
--- a/app/models/alchemy/essence_spree_product.rb
+++ b/app/models/alchemy/essence_spree_product.rb
@@ -1,6 +1,6 @@
 module Alchemy
   class EssenceSpreeProduct < ActiveRecord::Base
-    belongs_to :product, class_name: "Spree::Product", foreign_key: 'spree_product_id', readonly: true
+    belongs_to :product, class_name: "Spree::Product", foreign_key: 'spree_product_id'
 
     acts_as_essence(
       ingredient_column: 'spree_product_id',

--- a/app/models/alchemy/essence_spree_taxon.rb
+++ b/app/models/alchemy/essence_spree_taxon.rb
@@ -1,6 +1,6 @@
 module Alchemy
   class EssenceSpreeTaxon < ActiveRecord::Base
-    belongs_to :taxon, class_name: "Spree::Taxon", foreign_key: 'taxon_id', readonly: true
+    belongs_to :taxon, class_name: "Spree::Taxon", foreign_key: 'taxon_id'
 
     acts_as_essence(
       ingredient_column: 'taxon_id',


### PR DESCRIPTION
I was trying to set up a an app using:

Ruby 2.1.2
Rails 4.1.4
Alchemy 3.0.0
Spree 2.3.1

... but on deploying to Heroku, everything was crashing with this error: 

```
/app/vendor/bundle/ruby/2.1.0/gems/activesupport-4.1.4/lib/active_support/core_ext/hash/keys.rb:71:in `block in assert_valid_keys': Unknown key: :readonly. Valid keys are: :class_name, :class, :foreign_key, :validate, :autosave, :remote, :dependent, :primary_key, :inverse_of, :foreign_type, :polymorphic, :touch, :counter_cache (ArgumentError)
```

I found an issue in the [spree_alchemy](https://github.com/tesserakt/spree_alchemy/) gem which describes [basically the exact same problem](https://github.com/tesserakt/spree_alchemy/issues/4).... so I copied [their fix](https://github.com/tesserakt/spree_alchemy/commit/7d6cb856c43c0c8295054c9881fc2992f019b4a5).
