### PR TITLE
add auth helpers to spree api base

### DIFF
--- a/lib/spree/authentication_helpers.rb
+++ b/lib/spree/authentication_helpers.rb
@@ -26,3 +26,4 @@ module Spree
 end
 
 ApplicationController.send :include, Spree::AuthenticationHelpers
+Spree::Api::BaseController.send :include, Spree::AuthenticationHelpers


### PR DESCRIPTION
Spree API authentication was failing when looking up taxons in spree admin.
https://gist.github.com/BenMorganIO/5b786cf384169a8d9091

For some reason Spree Api wasnt picking up the auth helper override, this fixes it
