### PR TITLE
alchemy_spree without alchemy devise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .bundle/
 log/*.log
 pkg/

--- a/alchemy_spree.gemspec
+++ b/alchemy_spree.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Alchemy::Spree::VERSION
 
-  gem.add_dependency('alchemy_cms', ['~> 3.0.0.rc4'])
+  gem.add_dependency('alchemy_cms', ['>= 3.0.0.rc4'])
   gem.add_dependency('spree', ['>= 2.1', '< 3.0'])
 end

--- a/app/models/alchemy/user_decorator.rb
+++ b/app/models/alchemy/user_decorator.rb
@@ -1,7 +1,7 @@
 Alchemy.user_class.class_eval do
 
   def spree_roles
-    if admin?
+    if alchemy_roles.include?('admin')
       ::Spree::Role.where(name: 'admin')
     else
       ::Spree::Role.where('1 = 0') # aka. empty relation

--- a/app/models/alchemy/user_decorator.rb
+++ b/app/models/alchemy/user_decorator.rb
@@ -1,4 +1,4 @@
-Alchemy::User.class_eval do
+Alchemy.user_class.class_eval do
 
   def spree_roles
     if admin?

--- a/db/migrate/20131029215548_add_spree_fields_to_custom_user_table.rb
+++ b/db/migrate/20131029215548_add_spree_fields_to_custom_user_table.rb
@@ -1,7 +1,0 @@
-class AddSpreeFieldsToCustomUserTable < ActiveRecord::Migration
-  def up
-    add_column "alchemy_users", :spree_api_key, :string, :limit => 48
-    add_column "alchemy_users", :ship_address_id, :integer
-    add_column "alchemy_users", :bill_address_id, :integer
-  end
-end

--- a/db/migrate/20141028091133_add_spree_fields_to_alchemy_custom_user_table.rb
+++ b/db/migrate/20141028091133_add_spree_fields_to_alchemy_custom_user_table.rb
@@ -1,0 +1,8 @@
+# This migration comes from alchemy_spree (originally 20131029215548)
+class AddSpreeFieldsToAlchemyCustomUserTable < ActiveRecord::Migration
+  def up
+    add_column Alchemy.user_class.table_name, :spree_api_key, :string, :limit => 48
+    add_column Alchemy.user_class.table_name, :ship_address_id, :integer
+    add_column Alchemy.user_class.table_name, :bill_address_id, :integer
+  end
+end

--- a/lib/alchemy/spree/ability.rb
+++ b/lib/alchemy/spree/ability.rb
@@ -4,7 +4,7 @@ module Alchemy
       include CanCan::Ability
 
       def initialize(user)
-        if user && user.is_admin?
+        if user && user.alchemy_roles.include?('admin')
           can :index, :alchemy_admin_spree
         end
       end

--- a/lib/alchemy/spree/engine.rb
+++ b/lib/alchemy/spree/engine.rb
@@ -8,7 +8,7 @@ module Alchemy
       engine_name 'alchemy_spree'
 
       initializer 'spree.user_class', after: 'alchemy.include_authentication_helpers' do
-        ::Spree.user_class = Alchemy.user_class
+        ::Spree.user_class = Alchemy.user_class_name
         require File.join(File.dirname(__FILE__), '../../spree/authentication_helpers')
       end
 

--- a/lib/alchemy/spree/engine.rb
+++ b/lib/alchemy/spree/engine.rb
@@ -8,7 +8,7 @@ module Alchemy
       engine_name 'alchemy_spree'
 
       initializer 'spree.user_class', after: 'alchemy.include_authentication_helpers' do
-        ::Spree.user_class = "Alchemy::User"
+        ::Spree.user_class = Alchemy.user_class
         require File.join(File.dirname(__FILE__), '../../spree/authentication_helpers')
       end
 

--- a/lib/spree/authentication_helpers.rb
+++ b/lib/spree/authentication_helpers.rb
@@ -8,7 +8,7 @@ module Spree
     end
 
     def spree_current_user
-      current_user
+      alchemy.current_user
     end
 
     def spree_login_path

--- a/lib/spree/authentication_helpers.rb
+++ b/lib/spree/authentication_helpers.rb
@@ -8,19 +8,19 @@ module Spree
     end
 
     def spree_current_user
-      alchemy.current_user
+      send Alchemy.current_user_method
     end
 
     def spree_login_path
-      alchemy.login_path
+      Alchemy.login_path
     end
 
     def spree_signup_path
-      alchemy.signup_path
+      Alchemy.signup_path
     end
 
     def spree_logout_path
-      alchemy.logout_path
+      Alchemy.logout_path
     end
   end
 end


### PR DESCRIPTION
relates to issue #15

Coincidentally, I needed the same functionality.
(alchemy_spree without alchemy_devise)
This adaptation works well in my environment. (custom authentication with devise: alchemy / spree)
Unfortunately, at the moment I do not have time to test if it works with alchemy_devise yet.