### PR TITLE
Asset names passed to helpers should not include the "/assets/" prefix

### DIFF
--- a/config/initializers/alchemy.rb
+++ b/config/initializers/alchemy.rb
@@ -5,6 +5,6 @@ Alchemy::Modules.register_module({
     controller: 'alchemy/admin/spree',
     action: 'index',
     name: 'Spree',
-    image: '/assets/alchemy_spree/alchemy_module_icon.png'
+    image: 'alchemy_spree/alchemy_module_icon.png'
   }
 })


### PR DESCRIPTION
Gemfile & Gemfile.lock: https://gist.github.com/AlanLattimore/4ab347cebe276c4dd74a
