### PR TITLE
Integrate Alchemy with Spree.user_class

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,34 +40,71 @@ Install the migrations:
 $ rake alchemy_spree:install:migrations
 ```
 
-Migrate the database:
+Do the next step before running the migrations.
 
-```sh
-$ rake db:migrate
-```
 
 ### Authentication system installation
 
-Since Alchemy 3.0 has dropped the authentication from its core, you will need to choose one authentication system. The easiest choice is to use the [alchemy-devise gem](https://github.com/magiclabs/alchemy-devise).
+Both Alchemy 3.0 and Spree come without an authentication system in place. You will need to choose an authentication system yourself. There are 3 available options. Whichever you choose, you need to instruct Spree & Alchemy about your choice of authentication system. Here are the steps for each option:
 
-To install alchemy-devise:
 
-```ruby
-# Gemfile
-gem 'alchemy-devise', '~> 2.0'
-```
+1. Use [Spree Auth Devise](https://github.com/spree/spree_auth_devise)
 
-And then execute:
+  Recommended for:
+    - an existing Spree installation. `gem 'spree_auth_devise'` should already be in your Gemfile.
+    - you are just adding Alchemy
+
+
+  To use Spree Auth Devise, instruct Alchemy to use the Spree Auth Devise user class:
+
+  ```ruby
+  # config/initializers/alchemy.rb
+  Alchemy.user_class_name = 'Spree::User'
+  Alchemy.current_user_method = :spree_current_user
+
+  # Include the Spree controller helpers to render the
+  # alchemy pages within the default Spree layout
+  Alchemy::BaseHelper.send :include, Spree::BaseHelper
+  Alchemy::BaseController.send :include, Spree::Core::ControllerHelpers::Common
+  Alchemy::BaseController.send :include, Spree::Core::ControllerHelpers::Store
+  ```
+
+2. Use [Alchemy Devise](https://github.com/magiclabs/alchemy-devise)
+
+  Recommended for:
+    - an existing Alchemy installation
+    - you don't have an authentication system and don't want to role an authentication system on your own.
+
+
+  To install alchemy-devise:
+
+  ```ruby
+  # Gemfile
+  gem 'alchemy-devise', '~> 2.0'
+  ```
+
+  And then execute:
+
+  ```sh
+  $ bundle
+  ```
+
+  Finally, you'll need to instruct Spree to use the Alchemy Devise user class:
+
+  ```ruby
+  # config/initializers/spree.rb
+  Spree.user_class = "Alchemy::User"
+  ```
+
+3. Build their own authentication
+
+
+---
+
+In either case, run the migrations now:
 
 ```sh
-$ bundle
-```
-
-Finally, you'll need to instruct Spree accordingly:
-
-```ruby
-# config/initializers/spree.rb
-Spree.user_class = "Alchemy::User"
+$ rake db:migrate
 ```
 
 ## Usage

--- a/app/models/alchemy/user_decorator.rb
+++ b/app/models/alchemy/user_decorator.rb
@@ -1,10 +1,10 @@
-Alchemy::User.class_eval do
+Spree.user_class.class_eval do
 
-  def spree_roles
+  def alchemy_roles
     if admin?
-      ::Spree::Role.where(name: 'admin')
+      %w(admin)
     else
-      ::Spree::Role.where('1 = 0') # aka. empty relation
+      []
     end
   end
 

--- a/db/migrate/20131029215548_add_spree_fields_to_custom_user_table.rb
+++ b/db/migrate/20131029215548_add_spree_fields_to_custom_user_table.rb
@@ -1,7 +1,9 @@
 class AddSpreeFieldsToCustomUserTable < ActiveRecord::Migration
   def up
-    add_column "alchemy_users", :spree_api_key, :string, :limit => 48
-    add_column "alchemy_users", :ship_address_id, :integer
-    add_column "alchemy_users", :bill_address_id, :integer
+    if ::Spree.user_class == "Alchemy::User"
+      add_column "alchemy_users", :spree_api_key, :string, :limit => 48
+      add_column "alchemy_users", :ship_address_id, :integer
+      add_column "alchemy_users", :bill_address_id, :integer
+    end
   end
 end

--- a/lib/alchemy/spree/ability.rb
+++ b/lib/alchemy/spree/ability.rb
@@ -4,7 +4,7 @@ module Alchemy
       include CanCan::Ability
 
       def initialize(user)
-        if user && user.is_admin?
+        if user && user.admin?
           can :index, :alchemy_admin_spree
         end
       end

--- a/lib/alchemy/spree/engine.rb
+++ b/lib/alchemy/spree/engine.rb
@@ -8,8 +8,9 @@ module Alchemy
       engine_name 'alchemy_spree'
 
       initializer 'spree.user_class', after: 'alchemy.include_authentication_helpers' do
-        ::Spree.user_class = "Alchemy::User"
-        require File.join(File.dirname(__FILE__), '../../spree/authentication_helpers')
+        if ::Spree.user_class == "Alchemy::User"
+          require File.join(File.dirname(__FILE__), '../../spree/authentication_helpers')
+        end
       end
 
       def self.activate


### PR DESCRIPTION
When adding alchemy_spree, the presumption is that that there is
a Spree store, which already uses an authentication system and the
user class is referred by Spree.user_class.

Also fixes logic in User Decorator and eliminates decorating complexity.

Adds suggestion in README on integrating the Alchemy pages with the Spree layout
without adding magic to the engine.

Tested with Spree 3.0 and Alchemy master