### PR TITLE
Add translation for "none" option in product select

### DIFF
--- a/app/views/alchemy/essences/_essence_spree_product_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_spree_product_editor.html.erb
@@ -8,7 +8,7 @@
       :name,
       content.essence.spree_product_id
     ),
-    include_blank: true,
+    include_blank: t(".none"),
     class: ["alchemy_selectbox", "essence_editor_select", html_options[:class]].join(' '),
     style: html_options[:style]
   ) %>

--- a/app/views/alchemy/essences/_essence_spree_taxon_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_spree_taxon_editor.html.erb
@@ -10,7 +10,7 @@
       :name,
       content.essence.taxon_id
     ),
-    include_blank: true,
+    include_blank: t(".none"),
     class: ["alchemy_selectbox", "essence_editor_select", html_options[:class]].join(' '),
     style: html_options[:style]
   ) %>

--- a/config/locales/alchemy_spree.de.yml
+++ b/config/locales/alchemy_spree.de.yml
@@ -1,0 +1,5 @@
+de:
+  alchemy:
+    essences:
+      essence_spree_product_editor:
+        none: "Keins"

--- a/config/locales/alchemy_spree.de.yml
+++ b/config/locales/alchemy_spree.de.yml
@@ -3,3 +3,5 @@ de:
     essences:
       essence_spree_product_editor:
         none: "Keins"
+      essence_spree_taxon_editor:
+        none: "Keins"

--- a/config/locales/alchemy_spree.en.yml
+++ b/config/locales/alchemy_spree.en.yml
@@ -1,0 +1,5 @@
+en:
+  alchemy:
+    essences:
+      essence_spree_product_editor:
+        none: "None"

--- a/config/locales/alchemy_spree.en.yml
+++ b/config/locales/alchemy_spree.en.yml
@@ -3,3 +3,5 @@ en:
     essences:
       essence_spree_product_editor:
         none: "None"
+      essence_spree_taxon_editor:
+        none: "None"

--- a/config/locales/alchemy_spree.es.yml
+++ b/config/locales/alchemy_spree.es.yml
@@ -1,0 +1,5 @@
+es:
+  alchemy:
+    essences:
+      essence_spree_product_editor:
+        none: "Ninguno"

--- a/config/locales/alchemy_spree.es.yml
+++ b/config/locales/alchemy_spree.es.yml
@@ -3,3 +3,5 @@ es:
     essences:
       essence_spree_product_editor:
         none: "Ninguno"
+      essence_spree_taxon_editor:
+        none: "Ninguno"


### PR DESCRIPTION
Before this commit, it was very hard to find the "none" option
when selecting a product. This uses a translation instead of "true",
making the "none" option more accessible.